### PR TITLE
make overlap default consistent with constraints

### DIFF
--- a/Code/calc_diss_shear.m
+++ b/Code/calc_diss_shear.m
@@ -165,13 +165,13 @@ SH_HP = filter(bh, ah, SH_HP); % Filter backwards
 SH_HP = flipud(SH_HP); % Flip backwards to forward
 
 dissInfo = struct();
-dissInfo.fft_length = round(fft_length_sec * pInfo.fs_fast); % FFT length in bins
-dissInfo.diss_length = diss_length_factor * dissInfo.fft_length; % Dissipation length in bins
+dissInfo.fft_length = round(fft_length_sec * pInfo.fs_fast); % number of points for fft
+dissInfo.diss_length = diss_length_factor * dissInfo.fft_length; % number of points (fft lengths) for dissipation estimate
 
 if pars.diss_overlap_factor == 0
     dissInfo.overlap = 0; % No overlap
 else
-    dissInfo.overlap = ceil(dissInfo.diss_length / pars.diss_overlap_factor); % Number of bins to overlap
+    dissInfo.overlap = ceil(dissInfo.diss_length * pars.diss_overlap_factor); % nuber of overlapping dissipation points
 end
 
 for name = ["goodman", "f_limit", "fit_2_isr", "f_AA", "fit_order"]

--- a/Code/get_info.m
+++ b/Code/get_info.m
@@ -94,7 +94,7 @@ addParameter(p, "diss_trim_bottom_offset", 0, @isreal); % Meters added to bottom
 addParameter(p, "diss_reverse", false, validLogical); % Calculate dissipation backwards in time, for BBL on downcast
 addParameter(p, "diss_fft_length_sec", 0.5, validPositive); % Disspation FFT length in seconds
 addParameter(p, "diss_length_fac", 2, @(x) x>=2); % Multiples fft_length_sec to get dissipation length
-addParameter(p, "diss_overlap_factor", 2, @(x) x>=0 && x<=1); % Distance of the overlap of successive dissipation estimates, 0-> none
+addParameter(p, "diss_overlap_factor", 0.5, @(x) x>=0 && x<=1); % Distance of the overlap of successive dissipation estimates, 0-> none
 addParameter(p, "diss_fit_order", nan, validPositive); % Polynomial order of fit to shear spectra, in log-space
 addParameter(p, "diss_f_AA", nan, validPositive); % Cut-off frequency of the anti-aliasing filter
 addParameter(p, "diss_fit_2_isr", nan, validPositive); % Value of dissipation rate to switch from isr to integration

--- a/Code/get_info.m
+++ b/Code/get_info.m
@@ -93,8 +93,8 @@ addParameter(p, "diss_trim_top_offset", 0, @isreal); % Meters added to top trim 
 addParameter(p, "diss_trim_bottom_offset", 0, @isreal); % Meters added to bottom trim before dissipation calc
 addParameter(p, "diss_reverse", false, validLogical); % Calculate dissipation backwards in time, for BBL on downcast
 addParameter(p, "diss_fft_length_sec", 0.5, validPositive); % Disspation FFT length in seconds
-addParameter(p, "diss_length_fac", 2, @(x) x>=2); % Multiples fft_length_sec to get dissipation length
-addParameter(p, "diss_overlap_factor", 0.5, @(x) x>=0 && x<=1); % Distance of the overlap of successive dissipation estimates, 0-> none
+addParameter(p, "diss_length_fac", 2, @(x) x>=1); % Multiples fft_length_sec to get dissipation length
+addParameter(p, "diss_overlap_factor", 0.5, @(x) x>=0 && x<1); % Distance of the overlap of successive dissipation estimates, 0-> none
 addParameter(p, "diss_fit_order", nan, validPositive); % Polynomial order of fit to shear spectra, in log-space
 addParameter(p, "diss_f_AA", nan, validPositive); % Cut-off frequency of the anti-aliasing filter
 addParameter(p, "diss_fit_2_isr", nan, validPositive); % Value of dissipation rate to switch from isr to integration


### PR DESCRIPTION
Default value of the overlap parameter is inconsistent with 0 <= x <= 1